### PR TITLE
Avoid Reload Request Rate Limit

### DIFF
--- a/playwright_recaptcha/recaptchav2/async_solver.py
+++ b/playwright_recaptcha/recaptchav2/async_solver.py
@@ -650,11 +650,11 @@ class AsyncSolver(BaseSolver[Page]):
 
                 return self._token
 
+            time_to_wait = max(1 - (time.time() - click_timestamp), 0)
+            await self._page.wait_for_timeout(time_to_wait * 1000)
+
         while not await recaptcha_box.any_challenge_is_visible():
             await self._page.wait_for_timeout(250)
-
-        time_to_wait = max(1 - (time.time() - click_timestamp), 0)
-        await self._page.wait_for_timeout(time_to_wait * 1000)
 
         if image_challenge and await recaptcha_box.image_challenge_button.is_visible():
             await recaptcha_box.image_challenge_button.click()

--- a/playwright_recaptcha/recaptchav2/async_solver.py
+++ b/playwright_recaptcha/recaptchav2/async_solver.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import functools
 import re
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from io import BytesIO
@@ -633,6 +634,7 @@ class AsyncSolver(BaseSolver[Page]):
             raise RecaptchaRateLimitError
 
         if await recaptcha_box.checkbox.is_visible():
+            click_timestamp = time.time()
             await self._click_checkbox(recaptcha_box)
 
             if self._token is not None:
@@ -650,6 +652,9 @@ class AsyncSolver(BaseSolver[Page]):
 
         while not await recaptcha_box.any_challenge_is_visible():
             await self._page.wait_for_timeout(250)
+
+        time_to_wait = max(1 - (time.time() - click_timestamp), 0)
+        await self._page.wait_for_timeout(time_to_wait * 1000)
 
         if image_challenge and await recaptcha_box.image_challenge_button.is_visible():
             await recaptcha_box.image_challenge_button.click()

--- a/playwright_recaptcha/recaptchav2/sync_solver.py
+++ b/playwright_recaptcha/recaptchav2/sync_solver.py
@@ -586,11 +586,11 @@ class SyncSolver(BaseSolver[Page]):
 
                 return self._token
 
+            time_to_wait = max(1 - (time.time() - click_timestamp), 0)
+            self._page.wait_for_timeout(time_to_wait * 1000)
+
         while not recaptcha_box.any_challenge_is_visible():
             self._page.wait_for_timeout(250)
-
-        time_to_wait = max(1 - (time.time() - click_timestamp), 0)
-        self._page.wait_for_timeout(time_to_wait * 1000)
 
         if image_challenge and recaptcha_box.image_challenge_button.is_visible():
             recaptcha_box.image_challenge_button.click()

--- a/playwright_recaptcha/recaptchav2/sync_solver.py
+++ b/playwright_recaptcha/recaptchav2/sync_solver.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import re
+import time
 from datetime import datetime
 from io import BytesIO
 from json import JSONDecodeError
@@ -569,6 +570,7 @@ class SyncSolver(BaseSolver[Page]):
             raise RecaptchaRateLimitError
 
         if recaptcha_box.checkbox.is_visible():
+            click_timestamp = time.time()
             self._click_checkbox(recaptcha_box)
 
             if self._token is not None:
@@ -586,6 +588,9 @@ class SyncSolver(BaseSolver[Page]):
 
         while not recaptcha_box.any_challenge_is_visible():
             self._page.wait_for_timeout(250)
+
+        time_to_wait = max(1 - (time.time() - click_timestamp), 0)
+        self._page.wait_for_timeout(time_to_wait * 1000)
 
         if image_challenge and recaptcha_box.image_challenge_button.is_visible():
             recaptcha_box.image_challenge_button.click()


### PR DESCRIPTION
Google has possibly made changes to where you have to wait at least one second after making the initial reload request before you can make another one, such as clicking on the audio challenge after clicking on the reCAPTCHA checkbox.